### PR TITLE
Change in request_manager.py

### DIFF
--- a/main/core/rest/request_manager.py
+++ b/main/core/rest/request_manager.py
@@ -42,9 +42,8 @@ class RequestManager(metaclass=Singleton):
         else:
             response = self.session.request(method, endpoint_url, params=kwargs)
 
-        # This doesn't allow to check for status codes that are not in the 2xx range
-        #if not response.ok:
-        #    raise RestError(response.status_code, endpoint_url, response)
+        if not response.ok:
+            return response.status_code, response.text
 
         return response.status_code, response.json()
 


### PR DESCRIPTION
This is a small patch to request_manager.py
The previous implementation raised error if the status code was different from 200, or if the response body was anything other than a JSON object (E.G: a string)
This modification allows creating negative test scenarios for the time being.