### PR TITLE
Changed a step as requested by previous PR review.

### DIFF
--- a/tests/api/features/attachments.feature
+++ b/tests/api/features/attachments.feature
@@ -61,6 +61,6 @@ Feature: Trello API Attachments
         Given I created a new card
         And I created an attachment on the card
         When I send a "DELETE" request to "/cards/{card}/attachments/{attachment}"
-        Then I receive a response with the "delete" schema
+        Then the attachment is deleted
         And the status code is "200"
     

--- a/tests/api/features/steps/attachments_steps.py
+++ b/tests/api/features/steps/attachments_steps.py
@@ -20,3 +20,11 @@ def step_impl(context):
     assert status_code == 200, 'Attachment was not created on the card'
     assert response['name'] == context.payload['name'], \
         f"Expected attachment's name to be {context.payload['name']} but it was {response['name']}"
+
+
+@then('the attachment is deleted')
+def step_impl(context):
+    """This step intends to verify that the attachment was deleted."""
+    status_code, response = attachments_manager.get_attachment(context.card['id'], context.attachment['id'])
+    assert status_code >= 400, f"Expected status code >= 400, got {status_code}"
+    assert 'invalid attachment' in response.lower(), f"Expected error message 'not found' but received: \n '{response}'"


### PR DESCRIPTION
Now the scenario verifies the attachment was deleted by sending a new "GET" request.